### PR TITLE
Fix accessibilité

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -15,6 +15,8 @@
 	body {
 		font-family: Lato, Helvetica, Arial, sans-serif;
 		@apply m-4;
+		background-color: #FFFFFF;
+		color: #000000;
 	}
 
 	h1 {

--- a/src/lib/thanks.svelte
+++ b/src/lib/thanks.svelte
@@ -10,10 +10,12 @@
 	</li>
 	<li>
 		<a href="https://nitter.net/Teddyruptif/">@Teddyruptif</a> pour son superbe
-		<a href="https://nitter.net/Teddyruptif/status/1649460414676172803">logo</a>
+		<a href="https://nitter.net/Teddyruptif/status/1649460414676172803">logo</a>&nbsp;:<br /> Parodie
+		du logo des Jeux Olympiques (cinq anneaux bleu, jaune, noir, vert, et rouge entrecroisés) les anneaux
+		ont un manche qui en fait des casseroles.
 	</li>
 	<li>Toustes les camarades qui ont contribué ou encouragé ce projet&nbsp;!</li>
-	<li><a href="https://solidairesinformatique.org">Syndiquez-vous !</a>
+	<li><a href="https://solidairesinformatique.org">Syndiquez-vous&nbsp;!</a></li>
 </ul>
 
 <style lang="postcss">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,12 +3,11 @@
 	import logoJO from '$lib/assets/logo-jo-small.jpg';
 </script>
 
-<header>
+<header role="banner">
 	<a href="/"
 		><img
 			src={logoJO}
-			alt="Parodie du logo des Jeux Olympiques (cinq anneaux bleu, jaune, noir, vert, et rouge entrecroisé) les anneaux ont un manche ce qui en fait des casseroles."
-			title="Source : https://nitter.net/Teddyruptif/status/1649460414676172803"
+			alt="100 jours de zbeul - Accueil"
 			class="mx-auto block text-center"
 			width="300"
 			height="178"
@@ -19,7 +18,7 @@
 	<p class="zbeul mb-6 text-center">Quels sont les départements qui zbeulent le plus&nbsp;?</p>
 </header>
 <slot />
-<footer class="mt-8">
+<footer class="mt-8" role="contentinfo">
 	<hr class="mb-2" />
 	<p><a href="https://github.com/cedricr/100joursdezbeul">Code source</a></p>
 </footer>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,29 +13,32 @@
 
 <svelte:head><title>100 jours de zbeul</title></svelte:head>
 
-<p class="zbeul olympic-red mt-16 text-center text-8xl">
-	{100 - dayNumber}
-</p>
+<main role="main">
+	<p class="mb-10 mt-16 text-center">
+		<span class="zbeul olympic-red block text-8xl">
+			{100 - dayNumber}
+		</span>
+		<span class="block text-xl">jours restants</span>
+	</p>
 
-<p class=" mb-10 text-center text-xl">jours restants</p>
+	<h2 class="zbeul mb-2">Classement temporaire au {formattedDate}</h2>
+	<p class="mb-6 text-center italic">tenant compte des données jusqu’au 20 avril inclus.</p>
 
-<h2 class="zbeul mb-2">Classement temporaire au {formattedDate}</h2>
-<p class="mb-6 text-center italic">tenant compte des données jusqu’au 20 avril inclus.</p>
+	<div class="mx-auto mb-6 max-w-sm text-xl">
+		<ol>
+			{#each resultLines as result, i}
+				<li class="mb-3 flex flex-row justify-between gap-3" class:winner={i === 0}>
+					<div>{i + 1}. {getDepartmentName(result[0])}</div>
+					<div>{result[1]} pts</div>
+				</li>
+			{/each}
+		</ol>
+	</div>
 
-<div class="mx-auto mb-6 max-w-sm text-xl">
-	<ol>
-		{#each resultLines as result, i}
-			<li class="mb-3 flex flex-row justify-between gap-3" class:winner={i === 0}>
-				<div>{i + 1}. {getDepartmentName(result[0])}</div>
-				<div>{result[1]} pts</div>
-			</li>
-		{/each}
-	</ol>
-</div>
+	<p class="mb-12 text-center text-lg"><a href="/regles-du-jeu">Règles du jeu</a></p>
 
-<p class="mb-12 text-center text-lg"><a href="/regles-du-jeu">Règles du jeu</a></p>
-
-<Thanks />
+	<Thanks />
+</main>
 
 <style lang="postcss">
 	.olympic-red {

--- a/src/routes/regles-du-jeu/+page.svelte
+++ b/src/routes/regles-du-jeu/+page.svelte
@@ -3,34 +3,36 @@
 
 <svelte:head><title>Règles du jeu | 100 jours de zbeul</title></svelte:head>
 
-<div class="mx-auto mt-16 max-w-2xl">
-	<p>
-		En partant des <a
-			href="https://france.attac.org/se-mobiliser/retraites-pour-le-droit-a-une-retraite-digne-et-heureuse/article/on-ne-les-lache-pas-la-carte-des-mobilisations"
-			>données</a
-		>
-		compilées par Attac, on assigne à chaque événement un type de personne ciblée (secrétaire d’État,
-		ministre déléguée, ministre, Première ministre, présidente de l’AN, président de la République) et
-		un type d’action (manifestation, chahut, mise en sobriété, action conduisant à une fuite de la personnalité,
-		ou action créative). Les données finales sont accessibles dans le
-		<a href="https://github.com/cedricr/100joursdezbeul/blob/main/src/lib/assets/data.json"
-			>code source</a
-		>.
-	</p>
+<main role="main">
+	<div class="mx-auto mt-16 max-w-2xl">
+		<p>
+			En partant des <a
+				href="https://france.attac.org/se-mobiliser/retraites-pour-le-droit-a-une-retraite-digne-et-heureuse/article/on-ne-les-lache-pas-la-carte-des-mobilisations"
+				>données</a
+			>
+			compilées par Attac, on assigne à chaque événement un type de personne ciblée (secrétaire d’État,
+			ministre déléguée, ministre, Première ministre, présidente de l’AN, président de la République)
+			et un type d’action (manifestation, chahut, mise en sobriété, action conduisant à une fuite de
+			la personnalité, ou action créative). Les données finales sont accessibles dans le
+			<a href="https://github.com/cedricr/100joursdezbeul/blob/main/src/lib/assets/data.json"
+				>code source</a
+			>.
+		</p>
 
-	<p>
-		Chacune de ces actions attribue un certain nombre de points au département où elle se
-		passe&nbsp;; le type de personne ciblée permet de multiplier ces points. Pour les événements où
-		plusieurs personnalités sont ciblées, les points sont comptés pour chacune.
-	</p>
+		<p>
+			Chacune de ces actions attribue un certain nombre de points au département où elle se
+			passe&nbsp;; le type de personne ciblée permet de multiplier ces points. Pour les événements
+			où plusieurs personnalités sont ciblées, les points sont comptés pour chacune.
+		</p>
 
-	<p>
-		Les barèmes, consultables dans le <a
-			href="https://github.com/cedricr/100joursdezbeul/blob/main/src/lib/utils.ts#L11"
-			>code source</a
-		>, vont sans doute évoluer rapidement dans les prochains jours.
-	</p>
-</div>
+		<p>
+			Les barèmes, consultables dans le <a
+				href="https://github.com/cedricr/100joursdezbeul/blob/main/src/lib/utils.ts#L11"
+				>code source</a
+			>, vont sans doute évoluer rapidement dans les prochains jours.
+		</p>
+	</div>
+</main>
 
 <style lang="postcss">
 	p {


### PR DESCRIPTION
Globalement, c'est bien mais il y avait 2-3 trucs à corriger :

* Ajouter une couleur de fond et une couleur de texte par défaut sur `body` pour éviter que les personnes personnalisant ces couleurs dans leur navigateur aient des contrastes incorrects ;
* Ajouter les `role=banner` sur le `header` du site, le `role="contentinfo` sur le `footer` du site pour la rétrocompatibilité avec les vieux lecteurs d'écran ;
* Ajouter l'élément `main` (avec `role="main"` pour rétrocompatibilité) pour le contenu principal ;
* Le logo de l'en-tête est un lien menant vers la page d'accueil donc on va lui mettre une alternative permettant de savoir où va ce lien. On décrira donc le logo plutôt là où on remercie son auteur. L'attribut `title` avec la source n'est pas pertinent. De plus, les lecteurs d'écran vont le lire et la lecture d'une URL est particulièrement pénible. Il y a déjà le lien vers la source en bas de la page, c'est suffisant ;
* Placer le "X jours restants" dans un seul paragraphe car ce n'est bien qu'une seule et même "phrase".

N'hésites pas à revenir vers moi s'il y a un point qui n'est pas clair.