### PR TITLE
add manif for Vendome

### DIFF
--- a/src/lib/assets/data.json
+++ b/src/lib/assets/data.json
@@ -880,7 +880,8 @@
     "codeInsee": 41269,
     "actions": [
       "chahut",
-      "fuite"
+      "fuite",
+      "manif"
     ],
     "cibles": [
       "president-rep"


### PR DESCRIPTION
Je propose "manif" en plus pour Vendôme suite à la remarque https://github.com/cedricr/100joursdezbeul/pull/14#issuecomment-1526083989
Car il y a eu blocage de la national https://twitter.com/EmilioMeslet/status/1650851995220099075?t=8SwqvOBNLTz9bjMZc6W3ig et envahissement des voies de la gare https://twitter.com/AnthonyLebbos/status/1650822186326802432?t=StbI8fVGCdUu6TsYeb8msA