### PR TITLE
Handle ambiguous city names using GPS coordinates

### DIFF
--- a/scripts/updateData/extractAttacData/transformers/extractCityAndDate.js
+++ b/scripts/updateData/extractAttacData/transformers/extractCityAndDate.js
@@ -7,7 +7,7 @@ export default (previous, original) => previous.map(event => {
  const city = result[1].replaceAll(' -', '');
  const date = result[2];
   const [day, month] = date.split('/');
- const {ville: realCityName, codeInsee, departement} = extractLocation(city);
+ const {ville: realCityName, codeInsee, departement} = extractLocation(city, undefined, event.coordinates);
   const realDate = new Date(2023, month - 1, parseInt(day, 10));
   const formatedDate = formatDate(realDate);
   return {

--- a/scripts/updateData/utils/data.util.js
+++ b/scripts/updateData/utils/data.util.js
@@ -3,10 +3,22 @@ import inseeRemapping from '../data/inseeRemapping.json' assert { type: 'json' }
 
 const isEmpty = value => value;
 
-export const extractLocation = (city, dep) => {
+export const extractLocation = (city, dep, coord) => {
   const realCityName = inseeRemapping[city] || city;
   const matchingInseeCodes = inseeCodes.filter((code) => code.LIBELLE === realCityName && (!dep || `${code.COM}`.startsWith(dep)) );
-  const codeInsee = matchingInseeCodes.length === 1 ? matchingInseeCodes[0].COM : undefined;
+  let codeInsee = undefined;
+  if (matchingInseeCodes.length === 1) codeInsee = matchingInseeCodes[0].COM;
+  else if (matchingInseeCodes.length > 1) {
+    const closeInseeCodes = matchingInseeCodes
+      .filter((code) => 'COORD' in code)
+      .map((code) => ({
+        com: code.COM,
+        dist: Math.pow(code.COORD[0] - coord[0], 2) + Math.pow(code.COORD[1] - coord[1], 2)
+      }))
+      .sort((a, b) => a.dist - b.dist);
+    if (closeInseeCodes.length > 0 && closeInseeCodes[0].dist < 1)
+      codeInsee = closeInseeCodes[0].com;
+  }
   const departement = codeInsee ? `${codeInsee}`.slice(0,2) : '';
   return {
     ville: realCityName,

--- a/src/lib/assets/data.json
+++ b/src/lib/assets/data.json
@@ -782,7 +782,7 @@
   {
     "id": "un - Massy - 2023-04-24",
     "ville": "Massy",
-    "departement": "71",
+    "departement": "91",
     "ajout": "2023-04-26",
     "modif": "2023-04-26",
     "date": "2023-04-24",
@@ -790,7 +790,7 @@
     "liens": [
       "https://twitter.com/Solidaires_91/status/1650392337669935105?s=20"
     ],
-    "codeInsee": 71288,
+    "codeInsee": 91377,
     "actions": [
       "chahut"
     ],


### PR DESCRIPTION
Ce commit corrige une coquille: le Massy où a eu lieu le chahut visant Olivier Klein est le Massy du 91 et non du 71!

J'ai ajouté une vérification lorsque plusieurs villes ont le même nom: on trouve la ville la plus proche de l'évènement avec les coordonnées GPS.

Pour mettre à jour insee.json, j'ai utilisé les données JSON de datagouv:
[https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/](https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/)
Et le script suivant pour insérer les coordonnées GPS dans le fichier:
```js
import fs from 'fs';
import inseeCodes from './insee.json' assert { type: 'json' };
import citiesInfos from './laposte_hexasmal.json' assert { type: 'json' };

const inseeCodesToCoords = new Map();
for (const city of citiesInfos) {
  inseeCodesToCoords[parseInt(city.fields.code_commune_insee)] =
    city.fields.coordonnees_geographiques;
}

for (const city of inseeCodes) {
  if (city.COM in inseeCodesToCoords) {
    const coords = inseeCodesToCoords[city.COM];
    // datagouv uses coord format [lat, long], while OpenStreeMap uses [long, lat]
    city.COORD = [coords[1], coords[0]];
  }
}

fs.writeFile('insee_new.json', JSON.stringify(inseeCodes, null, 2), (error) => {
  if (error) {
      reject(error);
    }
  resolve();
});
```