### PR TITLE
nouvelle version des badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![zbeul](https://100joursdezbeul.fr/badge.svg)
+
 Lancer le projet localement:
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "100jours",
 			"version": "0.0.1",
 			"dependencies": {
+				"badgen": "^3.2.2",
 				"csv": "^6.2.10",
 				"nextcloud-node-client": "^1.8.1",
 				"node-fetch": "^3.3.1",
@@ -1408,6 +1409,11 @@
 			"peerDependencies": {
 				"postcss": "^8.1.0"
 			}
+		},
+		"node_modules/badgen": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/badgen/-/badgen-3.2.2.tgz",
+			"integrity": "sha512-MfBNhOzp+qbTg/3BAeaK1g+VE3uZ0CRfqMyrfyI3JUBz7b+DwxrZbYQdz5JQnibRih9YOVzXuVJl3A3xaWXfFQ=="
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -5407,6 +5413,11 @@
 				"picocolors": "^1.0.0",
 				"postcss-value-parser": "^4.2.0"
 			}
+		},
+		"badgen": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/badgen/-/badgen-3.2.2.tgz",
+			"integrity": "sha512-MfBNhOzp+qbTg/3BAeaK1g+VE3uZ0CRfqMyrfyI3JUBz7b+DwxrZbYQdz5JQnibRih9YOVzXuVJl3A3xaWXfFQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"badgen": "^3.2.2",
 		"csv": "^6.2.10",
 		"nextcloud-node-client": "^1.8.1",
 		"node-fetch": "^3.3.1",

--- a/src/routes/badge.svg/+server.js
+++ b/src/routes/badge.svg/+server.js
@@ -1,0 +1,23 @@
+import pkg from 'badgen';
+const { badgen } = pkg;
+
+import { LEADERBOARD } from '$lib/utils';
+
+export const prerender = true;
+
+const total_points = LEADERBOARD.reduce((acc, elem) => acc + elem[1], 0);
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ request }) {
+	const svgString = badgen({
+		label: 'zbeul 📣',
+		status: `${total_points} points`,
+		color: 'green'
+	});
+
+	return new Response(svgString, {
+		headers: {
+			'Content-Type': 'image/svg+xml'
+		}
+	});
+}


### PR DESCRIPTION
Pour remplacer #29 . (qui peut être clôturé, du coup)

Pour ce qui est de l'usage, j'avais pas réfléchi, je voulais juste proposer un truc un peu "swag" à coller sur le README. Avoir un badge par département était finalement peu pertinent et les stéréotypes déplacés, du coup je mets le score total : tous ensembe pour le zbeul.

cc @D4llo 