### PR TITLE
Fix CSS Flexbox de la liste des évènements

### DIFF
--- a/src/lib/event.svelte
+++ b/src/lib/event.svelte
@@ -13,29 +13,29 @@
 	}
 </script>
 
-<li class="mb-8 flex flex-row">
+<li class="mb-8 sm:flex sm:flex-row">
 	<div class="w-20 shrink-0">
 		{#if !hideDate}<strong>{getDateLabel(event.date)}</strong>{/if}
-		<span class="font-bold text-[#dd0220]">{@html getPointsDisplay(event.score)}</span><br />
+		<span class="font-bold text-[#dd0220]">{@html getPointsDisplay(event.score)}</span>
 	</div>
 	<div>
 		<span class="font-bold">{event.ville}&nbsp;:</span>
 		{event.description}
-		<div class="mt-1 flex flex-wrap gap-1">
+		<div class="mt-1 flex-wrap gap-1 sm:flex">
 			{#each event.actions as action}
 				<div class="tag action">
 					{ACTION_LABEL[action]}&nbsp;: {@html getPointsDisplay(ACTION_SCORE[action])}
 				</div>
 			{/each}
 		</div>
-		<div class="mt-1 flex flex-wrap gap-1">
+		<div class="mt-1 flex-wrap gap-1 sm:flex">
 			{#each event.cibles as target}
 				<div class="tag target">
 					{TARGET_LABEL[target.role.code]}&nbsp;: x{TARGET_MULTIPLIER[target.role.code]}
 				</div>
 			{/each}
 		</div>
-		<div class="mt-1 flex flex-wrap gap-1">
+		<div class="mt-1 flex-wrap gap-1 sm:flex">
 			{#each liens as link}
 				<div class="tag target">
 					<a href={link.url}>{link.text}</a>
@@ -47,7 +47,7 @@
 
 <style lang="postcss">
 	.tag {
-		@apply whitespace-nowrap py-0.5 pr-2 text-xs font-bold;
+		@apply py-0.5 pr-2 text-xs font-bold;
 	}
 
 	.action {


### PR DESCRIPTION
Il y avait un bug où, pour une certaine petite taille d'écran, les contenus étaient trop larges et généraient une scrollbar horizontale (= bug d'accessibilité).

Avant :
![avant](https://user-images.githubusercontent.com/6296770/236852959-c0d26fed-afef-48d6-a04e-37ea61b9b657.png)

Après :
![après](https://user-images.githubusercontent.com/6296770/236852969-a0498fcc-e133-48b3-b7af-60cd5fa71627.png)
