### PR TITLE
Fix Safari bug : lien bloc dans le tableau qui ne fonctionne pas avec le tr en position relative

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,13 +83,15 @@
 					class:hover:bg-blue-100={rank > 3}
 				>
 					<th scope="row" class="p-1 sm:p-2">
-						<a
-							href="/departement/{code}"
-							class="link-block no-underline"
-							class:font-bold={rank < 4}
-						>
-							{getDepartmentName(code)}
-						</a>
+						<div class="ranking-link-container">
+							<a
+								href="/departement/{code}"
+								class="link-block no-underline"
+								class:font-bold={rank < 4}
+							>
+								{getDepartmentName(code)}
+							</a>
+						</div>
 					</th>
 					<td class="p-1 text-center sm:p-2">
 						{#if rank === 1}
@@ -167,7 +169,7 @@
 	 */
 	@media not all and (min-resolution: 0.001dpcm) {
 		@supports (-webkit-appearance: none) and (stroke-color: transparent) {
-			.ranking th {
+			.ranking-link-container {
 				position: relative;
 			}
 		}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -66,7 +66,7 @@
 			<tr>
 				<th scope="col" class="p-1 sm:p-2">Département</th>
 				<th scope="col" class="p-1 text-center sm:p-2">Rang</th>
-				<th scope="col" class="p-1 text-center sm:p-2">Points</th>
+				<th scope="col" class="p-1 text-right sm:p-2">Points</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -83,15 +83,27 @@
 					class:hover:bg-blue-100={rank > 3}
 				>
 					<th scope="row" class="p-1 sm:p-2">
-						<div class="ranking-link-container">
-							<a
-								href="/departement/{code}"
-								class="link-block no-underline"
-								class:font-bold={rank < 4}
+						<a
+							href="/departement/{code}"
+							class="relative block no-underline"
+							class:font-bold={rank < 4}
+						>
+							{getDepartmentName(code)}<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="24"
+								height="24"
+								viewBox="0 0 24 24"
+								class="icon-link absolute bottom-0 right-0 top-0 ml-1.5 w-3.5 duration-200 ease-out"
+								aria-hidden="true"
+								class:fill-yellow-800={rank === 1}
+								class:fill-slate-800={rank === 2}
+								class:fill-orange-800={rank === 3}
+								class:fill-blue-800={rank > 3}
+								><path
+									d="M7.33 24l-2.83-2.829 9.339-9.175-9.339-9.167 2.83-2.829 12.17 11.996z"
+								/></svg
 							>
-								{getDepartmentName(code)}
-							</a>
-						</div>
+						</a>
 					</th>
 					<td class="p-1 text-center sm:p-2">
 						{#if rank === 1}
@@ -126,21 +138,7 @@
 						{/if}
 					</td>
 					<td class="p-1 text-right sm:p-2" class:font-bold={rank < 4}>
-						{score} pts<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							height="24"
-							viewBox="0 0 24 24"
-							class="icon-link ml-1.5 inline-block w-3.5 duration-200 ease-out"
-							aria-hidden="true"
-							class:fill-yellow-800={rank === 1}
-							class:fill-slate-800={rank === 2}
-							class:fill-orange-800={rank === 3}
-							class:fill-blue-800={rank > 3}
-							><path
-								d="M7.33 24l-2.83-2.829 9.339-9.175-9.339-9.167 2.83-2.829 12.17 11.996z"
-							/></svg
-						>
+						{score} pts
 					</td>
 				</tr>
 			{/each}
@@ -162,17 +160,6 @@
 		border-width: 1px 0;
 		border-style: solid;
 		border-color: #e5e7eb;
-	}
-
-	/** Fix Safari bug : lien bloc dans le tableau qui ne fonctionne pas avec le tr en position relative
-	 * Ciblage Safari 11+ > 15.6 https://www.browserstack.com/guide/create-browser-specific-css
-	 */
-	@media not all and (min-resolution: 0.001dpcm) {
-		@supports (-webkit-appearance: none) and (stroke-color: transparent) {
-			.ranking-link-container {
-				position: relative;
-			}
-		}
 	}
 
 	.ranking th:last-child,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -162,6 +162,17 @@
 		border-color: #e5e7eb;
 	}
 
+	/** Fix Safari bug : lien bloc dans le tableau qui ne fonctionne pas avec le tr en position relative
+	 * Ciblage Safari 11+ https://www.browserstack.com/guide/create-browser-specific-css
+	 */
+	@media not all and (min-resolution: 0.001dpcm) {
+		@supports (-webkit-appearance: none) and (stroke-color: transparent) {
+			.ranking th {
+				position: relative;
+			}
+		}
+	}
+
 	.ranking th:last-child,
 	.ranking td:last-child {
 		min-width: 7rem;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -85,7 +85,7 @@
 					<th scope="row" class="p-1 sm:p-2">
 						<a
 							href="/departement/{code}"
-							class="relative block no-underline"
+							class="relative block pr-4 no-underline"
 							class:font-bold={rank < 4}
 						>
 							{getDepartmentName(code)}<svg
@@ -93,7 +93,7 @@
 								width="24"
 								height="24"
 								viewBox="0 0 24 24"
-								class="icon-link absolute bottom-0 right-0 top-0 ml-1.5 w-3.5 duration-200 ease-out"
+								class="icon-link absolute right-0 top-0.5 ml-1.5 w-3.5 duration-200 ease-out"
 								aria-hidden="true"
 								class:fill-yellow-800={rank === 1}
 								class:fill-slate-800={rank === 2}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -165,7 +165,7 @@
 	}
 
 	/** Fix Safari bug : lien bloc dans le tableau qui ne fonctionne pas avec le tr en position relative
-	 * Ciblage Safari 11+ https://www.browserstack.com/guide/create-browser-specific-css
+	 * Ciblage Safari 11+ > 15.6 https://www.browserstack.com/guide/create-browser-specific-css
 	 */
 	@media not all and (min-resolution: 0.001dpcm) {
 		@supports (-webkit-appearance: none) and (stroke-color: transparent) {


### PR DESCRIPTION
J'ai tenté des trucs pour le bug avec Safari. En gros :

- soit, on ajoute du JS pour avoir une classe "safari" quand c'est le navigateur safari qui est détecté et je fais en sorte que, sur Safari, seul le département est cliquable dans le tableau des scores (j'ai essayé en CSS et avec la nouvelle version de Safari, j'ai pas trouvé de solution de détection) ;
- soit, toute la ligne du tableau des scores n'est plus cliquable mais uniquement le département, pour tous les navigateurs.

Solution choisie en l'absence de JS pour l'instant : seul le département devient cliquable pour tous les navigateurs.